### PR TITLE
Fix UnicodeEncodeError

### DIFF
--- a/src/youtube_playlist_to_m3u/main.py
+++ b/src/youtube_playlist_to_m3u/main.py
@@ -90,7 +90,7 @@ def main(args):
 
     if extractor.entries is not None :
         m3u = build_m3u(extractor.entries)
-        with open(args.outputfile, "w") as output_file:
+        with open(args.outputfile, "w", encoding='utf-8') as output_file:
             output_file.writelines(m3u)
 
 def run():


### PR DESCRIPTION
If the Youtube videos contain unicode characters, main.py will throw the error:
UnicodeEncodeError: 'charmap' codec can't encode characters in position 14-20: character maps to <undefined>